### PR TITLE
change: implement combining line items same type. github issue: #1

### DIFF
--- a/shop.js
+++ b/shop.js
@@ -11,7 +11,12 @@ function getBasket() {
 
 function addToBasket(product) {
   const basket = getBasket();
-  basket.push(product);
+  const existing = basket.find((item) => item.product === product);
+  if (existing) {
+    existing.quantity += 1;
+  } else {
+    basket.push({ product, quantity: 1 });
+  }
   localStorage.setItem("basket", JSON.stringify(basket));
 }
 
@@ -30,11 +35,11 @@ function renderBasket() {
     if (cartButtonsRow) cartButtonsRow.style.display = "none";
     return;
   }
-  basket.forEach((product) => {
-    const item = PRODUCTS[product];
-    if (item) {
+  basket.forEach((item) => {
+    const product = PRODUCTS[item.product];
+    if (product) {
       const li = document.createElement("li");
-      li.innerHTML = `<span class='basket-emoji'>${item.emoji}</span> <span>${item.name}</span>`;
+      li.innerHTML = `<span class='basket-emoji'>${product.emoji}</span> <span>${item.quantity}x ${product.name}</span>`;
       basketList.appendChild(li);
     }
   });
@@ -51,8 +56,10 @@ function renderBasketIndicator() {
     indicator.className = "basket-indicator";
     basketLink.appendChild(indicator);
   }
-  if (basket.length > 0) {
-    indicator.textContent = basket.length;
+  // Sum all quantities for indicator
+  const total = basket.reduce((sum, item) => sum + item.quantity, 0);
+  if (total > 0) {
+    indicator.textContent = total;
     indicator.style.display = "flex";
   } else {
     indicator.style.display = "none";


### PR DESCRIPTION
Currently, when a customer adds multiple units of the same product to their shopping basket, each unit is displayed as a separate line item. This clutters the basket view and makes it difficult for users to see the total quantity of each item they intend to purchase.

Current Behavior:

Apple
Apple
Banana
Apple

Desired Behavior:

The shopping cart should group identical products into a single line item, with the quantity clearly indicated. For the same example, the cart should display:

3x Apple
1x Banana

This will provide a cleaner and more intuitive user experience.

Acceptance Criteria:

When a user adds a product to the cart that already exists in the cart, the quantity of that product line item is incremented by one.
When a user adds a new product to the cart, it is added as a new line item with a quantity of 1.
The quantity and the product name are displayed on the same line in the cart.
Affected Pages:

Basket Page